### PR TITLE
Fix language service crash on startup

### DIFF
--- a/MicaForEveryone.Win32/Window.cs
+++ b/MicaForEveryone.Win32/Window.cs
@@ -284,8 +284,11 @@ namespace MicaForEveryone.Win32
             _isDisposing = true;
             _ = NativeMethods.DestroyWindow(Handle);
             Handle = IntPtr.Zero;
-            Class.Dispose();
-            _ = NativeMethods.DestroyIcon(Class.Icon);
+            if (Class != null)
+            {
+                Class.Dispose();
+                _ = NativeMethods.DestroyIcon(Class.Icon);
+            }
         }
 
         /// <summary>

--- a/MicaForEveryone.Win32/Window.cs
+++ b/MicaForEveryone.Win32/Window.cs
@@ -4,6 +4,8 @@ using System.Runtime.InteropServices;
 using System.Text;
 using MicaForEveryone.Win32.PInvoke;
 
+#nullable enable
+
 namespace MicaForEveryone.Win32
 {
     public class Window : IDisposable
@@ -43,7 +45,7 @@ namespace MicaForEveryone.Win32
         /// Get a Window object if given window handle is a valid UI Automation window pattern.
         /// </summary>
         /// <returns>Null if handle is not valid, window object if valid.</returns>
-        public static Window GetWindowIfWindowPatternValid(IntPtr hWnd)
+        public static Window? GetWindowIfWindowPatternValid(IntPtr hWnd)
         {
             if (hWnd == IntPtr.Zero)
                 return null;
@@ -91,7 +93,7 @@ namespace MicaForEveryone.Win32
 
         private static EnumWindowsProc _windowEnumerator = new(WindowEnumeratorCallback);
 
-        private static event EventHandler<WindowEnumeratorEventArgs> EnumerateItem;
+        private static event EventHandler<WindowEnumeratorEventArgs>? EnumerateItem;
 
         private static bool WindowEnumeratorCallback([In] IntPtr hwnd, [In] IntPtr lParam)
         {
@@ -106,9 +108,9 @@ namespace MicaForEveryone.Win32
         /// <summary>
         /// set window title for calling <see cref="Activate"/> method
         /// </summary>
-        public string Title { get; set; }
+        public string Title { get; set; } = "";
 
-        public IntPtr Handle { get; protected set; }
+        public IntPtr Handle { get; protected set; } = IntPtr.Zero;
 
         /// <summary>
         /// Handle of parent window
@@ -153,7 +155,7 @@ namespace MicaForEveryone.Win32
 
         public WindowStylesEx StyleEx { get; set; } = 0;
 
-        public WindowClass Class { get; protected set; }
+        public WindowClass? Class { get; protected set; }
 
         /// <summary>
         /// Load an icon for window and return its handle. Icon will be destroyed when window is disposing.
@@ -220,7 +222,7 @@ namespace MicaForEveryone.Win32
         {
             Handle = NativeMethods.CreateWindowExW(
                 StyleEx,
-                Class.Atom,
+                Class!.Atom,
                 Title,
                 Style,
                 X, Y, Width, Height,
@@ -280,15 +282,12 @@ namespace MicaForEveryone.Win32
         /// </summary>
         public virtual void Dispose()
         {
-            if (_isDisposing) return;
+            if (_isDisposing || Class == null) return;
             _isDisposing = true;
             _ = NativeMethods.DestroyWindow(Handle);
             Handle = IntPtr.Zero;
-            if (Class != null)
-            {
-                Class.Dispose();
-                _ = NativeMethods.DestroyIcon(Class.Icon);
-            }
+            Class.Dispose();
+            _ = NativeMethods.DestroyIcon(Class.Icon);
         }
 
         /// <summary>
@@ -533,9 +532,9 @@ namespace MicaForEveryone.Win32
             DpiChanged?.Invoke(this, new WndProcEventArgs(hwnd));
         }
 
-        public event EventHandler<WndProcEventArgs> Create;
-        public event EventHandler<WndProcEventArgs> Destroy;
-        public event EventHandler<WndProcEventArgs> SizeChanged;
-        public event EventHandler<WndProcEventArgs> DpiChanged;
+        public event EventHandler<WndProcEventArgs>? Create;
+        public event EventHandler<WndProcEventArgs>? Destroy;
+        public event EventHandler<WndProcEventArgs>? SizeChanged;
+        public event EventHandler<WndProcEventArgs>? DpiChanged;
     }
 }

--- a/MicaForEveryone/Services/LanguageService.cs
+++ b/MicaForEveryone/Services/LanguageService.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using Windows.Globalization;
 using Windows.ApplicationModel.Resources.Core;
+using Windows.System.UserProfile;
 
 using MicaForEveryone.Interfaces;
 
@@ -17,24 +18,21 @@ namespace MicaForEveryone.Services
         public LanguageService()
         {
             SupportedLanguages = GetSupportedLanguages().ToArray();
-            foreach (var lstLanguage in Windows.System.UserProfile.GlobalizationPreferences.Languages)
-            {
-                var userLanuage = new Windows.Globalization.Language(lstLanguage);
-                var selLanguage = SupportedLanguages.FirstOrDefault(
-                language => userLanuage.LanguageTag == language.LanguageTag
-                );
-                if (selLanguage != null)
-                {
-                    CurrentLanguage = selLanguage;
-                    break;
-                }
-            }
-            if (CurrentLanguage == null)
+
+            var preferredLanguageTag = GlobalizationPreferences.Languages.FirstOrDefault(
+                l => SupportedLanguages.Any(
+                    sl => l.ToLower().StartsWith(sl.LanguageTag.ToLower())));
+
+            if (preferredLanguageTag == null)
             {
                 CurrentLanguage = SupportedLanguages[0];
             }
+            else
+            {
+                CurrentLanguage = SupportedLanguages.First(
+                    l => preferredLanguageTag.ToLower().StartsWith(l.LanguageTag.ToLower()));
+            }
         }
-
 
         public Language[] SupportedLanguages { get; }
 

--- a/MicaForEveryone/Services/LanguageService.cs
+++ b/MicaForEveryone/Services/LanguageService.cs
@@ -17,11 +17,24 @@ namespace MicaForEveryone.Services
         public LanguageService()
         {
             SupportedLanguages = GetSupportedLanguages().ToArray();
-
-            var currentLanguage = ResourceManager.Current.DefaultContext.Languages[0];
-            CurrentLanguage = SupportedLanguages.First(
-                language => currentLanguage.StartsWith(language.LanguageTag));
+            foreach (var lstLanguage in Windows.System.UserProfile.GlobalizationPreferences.Languages)
+            {
+                var userLanuage = new Windows.Globalization.Language(lstLanguage);
+                var selLanguage = SupportedLanguages.FirstOrDefault(
+                language => userLanuage.LanguageTag == language.LanguageTag
+                );
+                if (selLanguage != null)
+                {
+                    CurrentLanguage = selLanguage;
+                    break;
+                }
+            }
+            if (CurrentLanguage == null)
+            {
+                CurrentLanguage = SupportedLanguages[0];
+            }
         }
+
 
         public Language[] SupportedLanguages { get; }
 

--- a/MicaForEveryone/Services/LanguageService.cs
+++ b/MicaForEveryone/Services/LanguageService.cs
@@ -21,7 +21,7 @@ namespace MicaForEveryone.Services
 
             var preferredLanguageTag = GlobalizationPreferences.Languages.FirstOrDefault(
                 l => SupportedLanguages.Any(
-                    sl => l.ToLower().StartsWith(sl.LanguageTag.ToLower())));
+                    sl => l.StartsWith(sl.LanguageTag, StringComparison.OrdinalIgnoreCase)));
 
             if (preferredLanguageTag == null)
             {
@@ -30,7 +30,7 @@ namespace MicaForEveryone.Services
             else
             {
                 CurrentLanguage = SupportedLanguages.First(
-                    l => preferredLanguageTag.ToLower().StartsWith(l.LanguageTag.ToLower()));
+                    l => preferredLanguageTag.StartsWith(l.LanguageTag, StringComparison.OrdinalIgnoreCase));
             }
         }
 


### PR DESCRIPTION
We found a crash on startup in language service.
It happens when user preferred system language is not  supported or translated, LanguageService.CurrentLanguage should not be null on startup.
