### PR TITLE
[MSIX] Resolving Visual Studio building error

### DIFF
--- a/MicaForEveryone.Package/MicaForEveryone.Package.wapproj
+++ b/MicaForEveryone.Package/MicaForEveryone.Package.wapproj
@@ -1,113 +1,110 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup Condition="'$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '15.0'">
-    <VisualStudioVersion>15.0</VisualStudioVersion>
-  </PropertyGroup>
-  <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Debug|ARM64">
-      <Configuration>Debug</Configuration>
-      <Platform>ARM64</Platform>
-      <MfeProperties>RuntimeIdentifier=win-arm64;SelfContained=false</MfeProperties>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Debug|x64">
-      <Configuration>Debug</Configuration>
-      <Platform>x64</Platform>
-      <MfeProperties>RuntimeIdentifier=win-x64;SelfContained=false</MfeProperties>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|ARM64">
-      <Configuration>Release</Configuration>
-      <Platform>ARM64</Platform>
-      <MfeProperties>RuntimeIdentifier=win-arm64;SelfContained=false</MfeProperties>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|x64">
-      <Configuration>Release</Configuration>
-      <Platform>x64</Platform>
-      <MfeProperties>RuntimeIdentifier=win-x64;SelfContained=false</MfeProperties>
-    </ProjectConfiguration>
-  </ItemGroup>
-  <PropertyGroup>
-    <WapProjPath Condition="'$(WapProjPath)'==''">$(MSBuildExtensionsPath)\Microsoft\DesktopBridge\</WapProjPath>
-    <TargetPlatformVersion>10.0.22000.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.14393.0</TargetPlatformMinVersion>
-    <DefaultLanguage>en</DefaultLanguage>
-    <EntryPointProjectUniqueName>..\MicaForEveryone\MicaForEveryone.csproj</EntryPointProjectUniqueName>
-    <DebuggerType>CoreClr</DebuggerType>
-    <GenerateAppInstallerFile>False</GenerateAppInstallerFile>
-    <GenerateTestArtifacts>True</GenerateTestArtifacts>
-    <AppxBundlePlatforms>x64|arm64</AppxBundlePlatforms>
-    <AppxBundle>Always</AppxBundle>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(CertificateThumbprint)'==''">
-    <AppxPackageSigningEnabled>False</AppxPackageSigningEnabled>
-  </PropertyGroup>
-  <ItemGroup>
-    <AppxManifest Include="Package.appxmanifest">
-      <SubType>Designer</SubType>
-    </AppxManifest>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\MicaForEveryone\MicaForEveryone.csproj" SkipGetTargetFrameworkProperties="true" Properties="$(MfeProperties)" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="Assets\LargeTile.scale-100.png" />
-    <Content Include="Assets\LargeTile.scale-200.png" />
-    <Content Include="Assets\SmallTile.scale-100.png" />
-    <Content Include="Assets\SmallTile.scale-125.png" />
-    <Content Include="Assets\SmallTile.scale-150.png" />
-    <Content Include="Assets\SmallTile.scale-200.png" />
-    <Content Include="Assets\SmallTile.scale-400.png" />
-    <Content Include="Assets\Square150x150Logo.scale-100.png" />
-    <Content Include="Assets\Square150x150Logo.scale-125.png" />
-    <Content Include="Assets\Square150x150Logo.scale-150.png" />
-    <Content Include="Assets\Square150x150Logo.scale-200.png" />
-    <Content Include="Assets\Square150x150Logo.scale-400.png" />
-    <Content Include="Assets\Square44x44Logo.altform-lightunplated_targetsize-16.png" />
-    <Content Include="Assets\Square44x44Logo.altform-lightunplated_targetsize-24.png" />
-    <Content Include="Assets\Square44x44Logo.altform-lightunplated_targetsize-256.png" />
-    <Content Include="Assets\Square44x44Logo.altform-lightunplated_targetsize-32.png" />
-    <Content Include="Assets\Square44x44Logo.altform-lightunplated_targetsize-48.png" />
-    <Content Include="Assets\Square44x44Logo.altform-unplated_targetsize-16.png" />
-    <Content Include="Assets\Square44x44Logo.altform-unplated_targetsize-24.png" />
-    <Content Include="Assets\Square44x44Logo.altform-unplated_targetsize-256.png" />
-    <Content Include="Assets\Square44x44Logo.altform-unplated_targetsize-32.png" />
-    <Content Include="Assets\Square44x44Logo.altform-unplated_targetsize-48.png" />
-    <Content Include="Assets\Square44x44Logo.scale-100.png" />
-    <Content Include="Assets\Square44x44Logo.scale-125.png" />
-    <Content Include="Assets\Square44x44Logo.scale-150.png" />
-    <Content Include="Assets\Square44x44Logo.scale-200.png" />
-    <Content Include="Assets\Square44x44Logo.scale-400.png" />
-    <Content Include="Assets\Square44x44Logo.targetsize-16.png" />
-    <Content Include="Assets\Square44x44Logo.targetsize-24.png" />
-    <Content Include="Assets\Square44x44Logo.targetsize-256.png" />
-    <Content Include="Assets\Square44x44Logo.targetsize-32.png" />
-    <Content Include="Assets\Square44x44Logo.targetsize-48.png" />
-    <Content Include="Assets\StoreLogo.scale-100.png" />
-    <Content Include="Assets\StoreLogo.scale-125.png" />
-    <Content Include="Assets\StoreLogo.scale-150.png" />
-    <Content Include="Assets\StoreLogo.scale-200.png" />
-    <Content Include="Assets\StoreLogo.scale-400.png" />
-  </ItemGroup>
-  <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.props" />
-  <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.targets" />
-  <Target Name="ReleaseMsix" DependsOnTargets="Build">
-    <PropertyGroup>
-      <ReleaseDirectory Condition="'$(ReleaseDirectory)'==''">..\Release</ReleaseDirectory>
-      <MsixName Condition="'$(MsixName)'==''">$(MSBuildProjectName)-$(Platform)-$(Configuration).msixbundle</MsixName>
-    </PropertyGroup>
-    <MakeDir Directories="$(ReleaseDirectory)" />
-    <Copy SourceFiles="$(AppxBundleOutput)" DestinationFiles="$(ReleaseDirectory)\$(MsixName)" />
-  </Target>
-  <!-- Additions for .NET Core 3 target -->
-  <PropertyGroup>
-    <PackageOutputGroups>@(PackageOutputGroups);__GetPublishItems</PackageOutputGroups>
-  </PropertyGroup>
-  <Target Name="_ValidateAppReferenceItems" />
-  <Target Name="_FixEntryPoint" AfterTargets="_ConvertItems">
-    <PropertyGroup>
-      <EntryPointExe>MicaForEveryone\MicaForEveryone.exe</EntryPointExe>
-    </PropertyGroup>
-  </Target>
-  <Target Name="PublishReferences" BeforeTargets="ExpandProjectReferences">
-    <MSBuild Projects="@(ProjectReference->'%(FullPath)')" BuildInParallel="$(BuildInParallel)" Targets="Publish" />
-  </Target>
+	<PropertyGroup Condition="'$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '15.0'">
+		<VisualStudioVersion>15.0</VisualStudioVersion>
+	</PropertyGroup>
+	<ItemGroup Label="ProjectConfigurations">
+		<ProjectConfiguration Include="Debug|ARM64">
+			<Configuration>Debug</Configuration>
+			<Platform>ARM64</Platform>
+		</ProjectConfiguration>
+		<ProjectConfiguration Include="Debug|x64">
+			<Configuration>Debug</Configuration>
+			<Platform>x64</Platform>
+		</ProjectConfiguration>
+		<ProjectConfiguration Include="Release|ARM64">
+			<Configuration>Release</Configuration>
+			<Platform>ARM64</Platform>
+		</ProjectConfiguration>
+		<ProjectConfiguration Include="Release|x64">
+			<Configuration>Release</Configuration>
+			<Platform>x64</Platform>
+		</ProjectConfiguration>
+	</ItemGroup>
+	<PropertyGroup>
+		<WapAlwaysBuildDependentProjects>true</WapAlwaysBuildDependentProjects>
+		<WapProjPath Condition="'$(WapProjPath)'==''">$(MSBuildExtensionsPath)\Microsoft\DesktopBridge\</WapProjPath>
+		<TargetPlatformVersion>10.0.22000.0</TargetPlatformVersion>
+		<TargetPlatformMinVersion>10.0.14393.0</TargetPlatformMinVersion>
+		<DefaultLanguage>en</DefaultLanguage>
+		<EntryPointProjectUniqueName>..\MicaForEveryone\MicaForEveryone.csproj</EntryPointProjectUniqueName>
+		<DebuggerType>CoreClr</DebuggerType>
+		<GenerateAppInstallerFile>False</GenerateAppInstallerFile>
+		<GenerateTestArtifacts>True</GenerateTestArtifacts>
+		<AppxBundlePlatforms>x64|arm64</AppxBundlePlatforms>
+		<AppxBundle>Always</AppxBundle>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(CertificateThumbprint)'==''">
+		<AppxPackageSigningEnabled>False</AppxPackageSigningEnabled>
+	</PropertyGroup>
+	<ItemGroup>
+		<AppxManifest Include="Package.appxmanifest">
+			<SubType>Designer</SubType>
+		</AppxManifest>
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\MicaForEveryone\MicaForEveryone.csproj" SkipGetTargetFrameworkProperties="true" Properties="SelfContained=false" />
+	</ItemGroup>
+	<ItemGroup>
+		<Content Include="Assets\LargeTile.scale-100.png" />
+		<Content Include="Assets\LargeTile.scale-200.png" />
+		<Content Include="Assets\SmallTile.scale-100.png" />
+		<Content Include="Assets\SmallTile.scale-125.png" />
+		<Content Include="Assets\SmallTile.scale-150.png" />
+		<Content Include="Assets\SmallTile.scale-200.png" />
+		<Content Include="Assets\SmallTile.scale-400.png" />
+		<Content Include="Assets\Square150x150Logo.scale-100.png" />
+		<Content Include="Assets\Square150x150Logo.scale-125.png" />
+		<Content Include="Assets\Square150x150Logo.scale-150.png" />
+		<Content Include="Assets\Square150x150Logo.scale-200.png" />
+		<Content Include="Assets\Square150x150Logo.scale-400.png" />
+		<Content Include="Assets\Square44x44Logo.altform-lightunplated_targetsize-16.png" />
+		<Content Include="Assets\Square44x44Logo.altform-lightunplated_targetsize-24.png" />
+		<Content Include="Assets\Square44x44Logo.altform-lightunplated_targetsize-256.png" />
+		<Content Include="Assets\Square44x44Logo.altform-lightunplated_targetsize-32.png" />
+		<Content Include="Assets\Square44x44Logo.altform-lightunplated_targetsize-48.png" />
+		<Content Include="Assets\Square44x44Logo.altform-unplated_targetsize-16.png" />
+		<Content Include="Assets\Square44x44Logo.altform-unplated_targetsize-24.png" />
+		<Content Include="Assets\Square44x44Logo.altform-unplated_targetsize-256.png" />
+		<Content Include="Assets\Square44x44Logo.altform-unplated_targetsize-32.png" />
+		<Content Include="Assets\Square44x44Logo.altform-unplated_targetsize-48.png" />
+		<Content Include="Assets\Square44x44Logo.scale-100.png" />
+		<Content Include="Assets\Square44x44Logo.scale-125.png" />
+		<Content Include="Assets\Square44x44Logo.scale-150.png" />
+		<Content Include="Assets\Square44x44Logo.scale-200.png" />
+		<Content Include="Assets\Square44x44Logo.scale-400.png" />
+		<Content Include="Assets\Square44x44Logo.targetsize-16.png" />
+		<Content Include="Assets\Square44x44Logo.targetsize-24.png" />
+		<Content Include="Assets\Square44x44Logo.targetsize-256.png" />
+		<Content Include="Assets\Square44x44Logo.targetsize-32.png" />
+		<Content Include="Assets\Square44x44Logo.targetsize-48.png" />
+		<Content Include="Assets\StoreLogo.scale-100.png" />
+		<Content Include="Assets\StoreLogo.scale-125.png" />
+		<Content Include="Assets\StoreLogo.scale-150.png" />
+		<Content Include="Assets\StoreLogo.scale-200.png" />
+		<Content Include="Assets\StoreLogo.scale-400.png" />
+	</ItemGroup>
+	<Import Project="$(WapProjPath)\Microsoft.DesktopBridge.props" />
+	<Import Project="$(WapProjPath)\Microsoft.DesktopBridge.targets" />
+	<Target Name="ReleaseMsix" DependsOnTargets="Build">
+		<PropertyGroup>
+			<ReleaseDirectory Condition="'$(ReleaseDirectory)'==''">..\Release</ReleaseDirectory>
+			<MsixName Condition="'$(MsixName)'==''">$(MSBuildProjectName)-$(Platform)-$(Configuration).msixbundle</MsixName>
+		</PropertyGroup>
+		<MakeDir Directories="$(ReleaseDirectory)" />
+		<Copy SourceFiles="$(AppxBundleOutput)" DestinationFiles="$(ReleaseDirectory)\$(MsixName)" />
+	</Target>
+	<!-- Additions for .NET Core 3 target -->
+	<PropertyGroup>
+		<PackageOutputGroups>@(PackageOutputGroups);__GetPublishItems</PackageOutputGroups>
+	</PropertyGroup>
+	<Target Name="_ValidateAppReferenceItems" />
+	<Target Name="_FixEntryPoint" AfterTargets="_ConvertItems">
+		<PropertyGroup>
+			<EntryPointExe>MicaForEveryone\MicaForEveryone.exe</EntryPointExe>
+		</PropertyGroup>
+	</Target>
+	<Target Name="PublishReferences" BeforeTargets="ExpandProjectReferences">
+		<MSBuild Projects="@(ProjectReference->'%(FullPath)')" BuildInParallel="$(BuildInParallel)" Targets="Publish" />
+	</Target>
 </Project>

--- a/MicaForEveryone/MicaForEveryone.csproj
+++ b/MicaForEveryone/MicaForEveryone.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <OutputType>WinExe</OutputType>
+		<ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+		<OutputType>WinExe</OutputType>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <TargetPlatformVersion>10.0.22000</TargetPlatformVersion>
         <AssetTargetFallback>uap10.0.22000</AssetTargetFallback>


### PR DESCRIPTION
1. I keep getting "multiple files with same relative path" error, so added `ErrorOnDuplicatePublishOutputFiles` to false as a workaround
2. Visual Studio constantly complains about `[something here]\MicaForEveryone.Shared\bin\[something here]\win-x64\MicaForEveryone.Shared.dll` missing. Notice how **win-x64** is in the path. I ended up removing the `RuntimeIdentifier` from the packaging project.
3. Add `WapAlwaysBuildDependentProjects` to the packaging project, which should workaround the broken `resources.pri` creation.
4. I cannot try uploading to the Partner Center since I lack an account, maybe @FireCubeStudios can try doing it?